### PR TITLE
Introduce CustomError

### DIFF
--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -76,6 +76,10 @@ module Liquid
           end
         rescue MemoryError => e
           raise e
+        rescue CustomError => e
+          e.markup_context ||= token.raw.strip
+          e.line_number    ||= token.line_number
+          raise e
         rescue UndefinedVariable, UndefinedDropMethod, UndefinedFilter => e
           context.handle_error(e, token.line_number)
           output << nil

--- a/lib/liquid/errors.rb
+++ b/lib/liquid/errors.rb
@@ -60,4 +60,5 @@ module Liquid
   UndefinedDropMethod = Class.new(Error)
   UndefinedFilter = Class.new(Error)
   MethodOverrideError = Class.new(Error)
+  CustomError = Class.new(Error)
 end


### PR DESCRIPTION
Introduce `Liquid::CustomError` which preserves context (markup & line no) before bubbling up.

To be subclassed and handled in the app.