### PR TITLE
Add render_time_limit to resource_limits

### DIFF
--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -74,7 +74,7 @@ module Liquid
           unless token.is_a?(Block) && token.blank?
             output << node_output
           end
-        rescue MemoryError => e
+        rescue MemoryError, TimeLimitError => e
           raise e
         rescue CustomError => e
           e.markup_context ||= token.raw.strip
@@ -100,6 +100,8 @@ module Liquid
       context.resource_limits.render_length += node_output.length
       if context.resource_limits.reached?
         raise MemoryError.new("Memory limits exceeded".freeze)
+      elsif context.resource_limits.time_limit_reached?
+        raise TimeLimitError.new("The time limit of #{context.resource_limits.render_time_limit}s was reached".freeze)
       end
       node_output
     end

--- a/lib/liquid/errors.rb
+++ b/lib/liquid/errors.rb
@@ -54,6 +54,7 @@ module Liquid
   StackLevelError = Class.new(Error)
   TaintedError = Class.new(Error)
   MemoryError = Class.new(Error)
+  TimeLimitError = Class.new(Error)
   ZeroDivisionError = Class.new(Error)
   FloatDomainError = Class.new(Error)
   UndefinedVariable = Class.new(Error)

--- a/lib/liquid/resource_limits.rb
+++ b/lib/liquid/resource_limits.rb
@@ -1,11 +1,12 @@
 module Liquid
   class ResourceLimits
-    attr_accessor :render_length, :render_score, :assign_score,
-      :render_length_limit, :render_score_limit, :assign_score_limit
+    attr_accessor :render_length, :render_score, :assign_score, :render_end_time,
+      :render_length_limit, :render_score_limit, :assign_score_limit, :render_time_limit
 
     def initialize(limits)
       @render_length_limit = limits[:render_length_limit]
       @render_score_limit = limits[:render_score_limit]
+      @render_time_limit = limits[:render_time_limit]
       @assign_score_limit = limits[:assign_score_limit]
       reset
     end
@@ -16,8 +17,23 @@ module Liquid
         (@assign_score_limit && @assign_score > @assign_score_limit)
     end
 
+    def time_limit_reached?
+      @render_time_limit && time > @render_end_time
+    end
+
     def reset
       @render_length = @render_score = @assign_score = 0
+      if @render_time_limit
+        @render_end_time = time + @render_time_limit
+      else
+        @render_end_time = nil
+      end
+    end
+
+    private
+
+    def time
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
     end
   end
 end

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -197,7 +197,7 @@ module Liquid
           @root.render(context)
         end
         result.respond_to?(:join) ? result.join : result
-      rescue Liquid::MemoryError => e
+      rescue Liquid::MemoryError, Liquid::TimeLimitError => e
         context.handle_error(e)
       ensure
         @errors = context.errors

--- a/test/integration/template_test.rb
+++ b/test/integration/template_test.rb
@@ -101,6 +101,21 @@ class TemplateTest < Minitest::Test
     assert_equal "", t.render!("bar" => SomethingWithLength.new)
   end
 
+  def test_resource_limits_render_time
+    t = Template.parse("{% for a in (1..100) %} foo {% endfor %}")
+    t.resource_limits.render_time_limit = 0.00000001
+    assert_equal "Liquid error: The time limit of 1.0e-08s was reached", t.render
+    assert t.resource_limits.time_limit_reached?
+
+    t.resource_limits.render_time_limit = 1000
+    assert_equal (" foo " * 100), t.render!
+    refute_nil t.resource_limits.render_end_time
+
+    t.resource_limits.render_time_limit = nil
+    assert_equal (" foo " * 100), t.render!
+    assert_nil t.resource_limits.render_end_time
+  end
+
   def test_resource_limits_render_length
     t = Template.parse("0123456789")
     t.resource_limits.render_length_limit = 5


### PR DESCRIPTION
While rendering blocks if the time exceeds the `render_time_limit` then error.